### PR TITLE
AWS S3 sync

### DIFF
--- a/src/main/scala/core/AwsS3.scala
+++ b/src/main/scala/core/AwsS3.scala
@@ -1,0 +1,55 @@
+import com.amazonaws.services.s3.{ AmazonS3, AmazonS3URI }
+import com.amazonaws.services.s3.model.{ListObjectsV2Request, S3ObjectSummary}
+import java.io.File
+import scala.collection.JavaConverters._
+import sbt.Logger
+
+object AwsS3 {
+
+  def files(amazonS3: AmazonS3, uri: AmazonS3URI)(implicit log: Logger): Map[AmazonS3URI, S3ObjectSummary] = {
+    @annotation.tailrec
+    def rec(request: ListObjectsV2Request, accumulator: Map[AmazonS3URI, S3ObjectSummary] = Map.empty): Map[AmazonS3URI, S3ObjectSummary] = {
+      log.debug(s"Reading in progress, ${accumulator.size} AWS S3 files found at the moment")
+
+      val result = amazonS3.listObjectsV2(request)
+      val newAccumulator = accumulator ++ result.getObjectSummaries()
+        .asScala
+        .map { summary =>
+          val uri = new AmazonS3URI(s"s3://${summary.getBucketName()}/${summary.getKey()}")
+          uri -> summary
+        }
+
+      Option(result.getNextContinuationToken) match {
+        case None => newAccumulator
+        case Some(token) =>
+          val newRequest = request.withContinuationToken(token)
+          rec(newRequest, newAccumulator)
+      }
+    }
+
+    val request = new ListObjectsV2Request()
+      .withBucketName(uri.getBucket)
+      .withPrefix(uri.getKey)
+
+    rec(request)
+  }
+
+  def sync(amazonS3: AmazonS3, local: Map[AmazonS3URI, File], remote: Map[AmazonS3URI, S3ObjectSummary])(implicit log: Logger): Unit =
+    (local.keys ++ remote.keys)
+      .map { uri => sync(amazonS3, uri, local.get(uri), remote.get(uri)) }
+      .foreach { sync => sync.unsafeRun }
+
+  def sync(amazonS3: AmazonS3, uri: AmazonS3URI, local: Option[File], remote: Option[S3ObjectSummary])(implicit log: Logger): AwsS3Sync = {
+    (local, remote) match {
+      case (Some(file), Some(summary)) if file.length != summary.getSize => AwsS3Sync.Upload(amazonS3, uri, file)
+      case (Some(file), None) => AwsS3Sync.Upload(amazonS3, uri, file)
+      case (None, Some(_)) => AwsS3Sync.Delete(amazonS3, uri)
+      case _ => AwsS3Sync.Skip(uri)
+    }
+  }
+}
+
+class AwsS3(amazonS3: AmazonS3)(implicit log: Logger) {
+  def files(uri: AmazonS3URI) = AwsS3.files(amazonS3, uri)
+  def sync(local: Map[AmazonS3URI, File], remote: Map[AmazonS3URI, S3ObjectSummary]) = AwsS3.sync(amazonS3, local, remote)
+}

--- a/src/main/scala/core/AwsS3Sync.scala
+++ b/src/main/scala/core/AwsS3Sync.scala
@@ -1,0 +1,25 @@
+import com.amazonaws.services.s3.{ AmazonS3, AmazonS3URI }
+import java.io.File
+import sbt.Logger
+
+sealed trait AwsS3Sync { def unsafeRun: Unit }
+object AwsS3Sync {
+  case class Skip(uri: AmazonS3URI)(implicit log: Logger) extends AwsS3Sync {
+    def unsafeRun: Unit =
+      log.debug(s"Skipping ${uri}")
+  }
+
+  case class Upload(amazonS3: AmazonS3, uri: AmazonS3URI, file: File)(implicit log: Logger) extends AwsS3Sync {
+    def unsafeRun: Unit = {
+      log.info(s"Uploading ${file} to ${uri}")
+      amazonS3.putObject(uri.getBucket, uri.getKey, file)
+    }
+  }
+
+  case class Delete(amazonS3: AmazonS3, uri: AmazonS3URI)(implicit log: Logger) extends AwsS3Sync {
+    def unsafeRun: Unit = {
+      log.info(s"Deleting ${uri}")
+      amazonS3.deleteObject(uri.getBucket, uri.getKey)
+    }
+  }
+}

--- a/src/main/scala/core/Local.scala
+++ b/src/main/scala/core/Local.scala
@@ -1,0 +1,15 @@
+
+import com.amazonaws.services.s3.AmazonS3URI
+import java.io.File
+
+object Local {
+
+  def files(site: Seq[(File, String)], uri: AmazonS3URI): Map[AmazonS3URI, File] =
+    site
+      .filter { case (file, target) => file.isFile() }
+      .map { case (file, target) =>
+        new AmazonS3URI(s"${uri}${target}", true) -> file
+      }
+      .toMap
+
+}


### PR DESCRIPTION
The plugin always pushed the full website to AWS S3. It was slow, "expensive", and unnecessary. Furthermore, previously pushed files would pollute the AWS S3 bucket.

A ticket was opened to rethink the process, https://github.com/plippe/sbt-awss3pages/issues/21. 

The code now creates a list of operations based on differences between local, and remote files. Identical files are skipped, and local changes are applied to AWS S3.  